### PR TITLE
chore: update extension copy and metadata for 1.0.3

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,15 +1,15 @@
 # Privacy Policy / 개인정보처리방침
 
-Last updated: February 22, 2026  
-최종 업데이트: 2026년 2월 22일
+Last updated: March 19, 2026  
+최종 업데이트: 2026년 3월 19일
 
-This policy applies to the Chrome extension **Agentation DOM Inspector**.
-본 방침은 크롬 확장 프로그램 **Agentation DOM Inspector**에 적용됩니다.
+This policy applies to the Chrome extension **DOM AI Bridge**.
+본 방침은 크롬 확장 프로그램 **DOM AI Bridge**에 적용됩니다.
 
 ## 1) What this extension does / 확장 프로그램 목적
 
-Agentation DOM Inspector helps users select and inspect DOM elements on webpages, then copy/export data in AI, JSON, or Share formats.  
-Agentation DOM Inspector는 웹페이지에서 DOM 요소를 선택/확인하고 AI, JSON, 공유용 포맷으로 복사/내보내기 하도록 돕습니다.
+DOM AI Bridge helps users select and inspect DOM elements on webpages, then copy/export data in AI, JSON, or Share formats.  
+DOM AI Bridge는 웹페이지에서 DOM 요소를 선택/확인하고 AI, JSON, 공유용 포맷으로 복사/내보내기 하도록 돕습니다.
 
 ## 2) Data processed / 처리되는 데이터
 
@@ -37,9 +37,9 @@ Agentation DOM Inspector는 웹페이지에서 DOM 요소를 선택/확인하고
 
 ### B. Data sent externally (only if user enables Webhook) / 외부 전송(사용자가 웹훅을 켠 경우에만)
 
-If Webhook is enabled by the user, the extension sends data to the user-configured webhook endpoint when the user copies in **Share** format.
+If Webhook is enabled by the user, the extension sends data to the user-configured webhook endpoint only when the user explicitly performs a copy action in a matched format.
 
-사용자가 Webhook 기능을 활성화한 경우에만, **공유용(Share)** 복사 시 사용자 지정 웹훅 엔드포인트로 데이터가 전송됩니다.
+사용자가 Webhook 기능을 활성화한 경우에만, 사용자가 명시적으로 복사 액션을 수행했을 때 매칭된 포맷 기준으로 사용자 지정 웹훅 엔드포인트로 데이터가 전송됩니다.
 
 Payload may include:
 
@@ -106,12 +106,20 @@ Webhook를 활성화하면 데이터가 사용자가 지정한 엔드포인트�
 - `activeTab`: interact with the current tab when user uses the extension
 - `storage`: save user preferences
 - `scripting`: run DOM selection/highlight behavior
-- `host_permissions (<all_urls>)`: support DOM inspection across arbitrary webpages
+- `host_permissions (<all_urls>)`: support DOM inspection across arbitrary webpages chosen by the user
+- `all_frames`: allow selection/highlighting inside iframe content as part of the current page
+- `match_about_blank`: include `about:blank` / `srcdoc` frames that many apps use internally
 
 - `activeTab`: 사용자가 확장 기능을 실행한 현재 탭과 상호작용
 - `storage`: 사용자 설정 저장
 - `scripting`: DOM 선택/하이라이트 기능 실행
-- `host_permissions (<all_urls>)`: 다양한 웹페이지에서 DOM 검사 기능 제공
+- `host_permissions (<all_urls>)`: 사용자가 연 웹페이지 전반에서 DOM 검사 기능 제공
+- `all_frames`: 현재 페이지의 일부인 iframe 내부 요소도 선택/하이라이트 가능하게 함
+- `match_about_blank`: 많은 웹앱이 내부적으로 사용하는 `about:blank` / `srcdoc` 프레임까지 포함함
+
+The extension is designed around explicit user action. Selection UI becomes active only after the user clicks the popup button or uses the shortcut, and export/transmission happens only when the user explicitly copies data.
+
+본 확장 프로그램은 명시적 사용자 액션을 전제로 설계되었습니다. 팝업 버튼 클릭 또는 단축키 실행 이후에만 선택 UI가 활성화되며, 내보내기/전송도 사용자가 직접 복사를 실행한 경우에만 발생합니다.
 
 ## 8) Changes to this policy / 방침 변경
 
@@ -126,4 +134,3 @@ Material updates will be reflected by changing the "Last updated" date above.
 - Developer: Yang Sejin  
 - GitHub: https://github.com/Sejin-999  
 - Email: sejinyang49@gmail.com
-

--- a/README.en.md
+++ b/README.en.md
@@ -13,12 +13,12 @@
   
   <p>A Chrome extension that lets you click DOM elements on any webpage and export them directly as AI prompts.</p>
   <p>Reads the real DOM directly — no virtual DOM dependency. Works on <b>any web environment</b>.</p>
-  <p>🌐 <a href="https://dom-ai-bridge.pages.dev/">Official site</a> (in development)</p>
+  <p>🌐 <a href="https://dom-ai-bridge.pages.dev/">Official site</a></p>
 
   <br>
 
   <a href="https://github.com/Sejin-999/DOM-AI-Bridge">
-    <img src="https://img.shields.io/badge/version-1.0.1-blue" alt="version" />
+    <img src="https://img.shields.io/badge/version-1.0.3-blue" alt="version" />
   </a>
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="manifest v3" />
   <img src="https://img.shields.io/badge/license-MIT-gray" alt="license" />
@@ -153,8 +153,8 @@ UI Annotations — https://example.com
 
 ## Installation
 
-### Chrome Web Store (V.1.0.1)
-> <a href = "https://chromewebstore.google.com/detail/dom-ai-bridge/gipfclelhppmafdlajajjkfepiiccnfd"> Download V 1.0.1 </a>
+### Chrome Web Store (V.1.0.3)
+> <a href = "https://chromewebstore.google.com/detail/dom-ai-bridge/gipfclelhppmafdlajajjkfepiiccnfd"> Download V 1.0.3 </a>
 
 ### Load as unpacked extension (developer mode)
 
@@ -261,11 +261,37 @@ MCP server integration is planned for deeper automation — **select DOM → AI 
 
 ---
 
-## Privacy
+## Permissions and Privacy
 
-- All data is processed **locally only**
-- No user data is stored on external servers
-- Works in air-gapped environments
+DOM AI Bridge works by letting the user select the real DOM on the page they are currently viewing.
+That is why it uses `host_permissions: <all_urls>`, but this does not mean background scraping or silent collection.
+
+### Why is `<all_urls>` required?
+
+- Users need to select DOM elements on arbitrary webpages, not only on a fixed allowlist of domains.
+- If host access were limited to a few domains, the extension would fail on many legitimate user workflows.
+- This permission exists to make the selection UI available broadly, not to collect browsing data for a remote service.
+
+### Why are `all_frames` and `match_about_blank` required?
+
+- Modern pages often split content into `iframe`s for editors, embeds, payment surfaces, dashboards, and app shells.
+- Without `all_frames: true`, the extension cannot consistently inspect or select elements inside those frames.
+- Without `match_about_blank: true`, it misses DOM inside `about:blank` or `srcdoc` frames.
+- These options are required for complete page-level DOM inspection, including embedded frame contexts.
+
+### When does it actually run?
+
+- The interactive selection flow only becomes active after the user clicks **Start Selecting** in the popup or uses the shortcut.
+- It is not an automatic crawler, auto-clicker, or silent collection tool.
+- Export happens only when the user explicitly clicks **Copy**.
+- Webhook delivery happens only if the user explicitly enables and configures it.
+
+### How is data handled?
+
+- Selection data, page URL, and user settings are processed and stored **locally by default**.
+- The developer does not run a default backend that stores extension data.
+- External transfer happens only if the user enables Webhook and performs a copy action.
+- Core functionality still works in fully offline or air-gapped environments.
 
 Details: [Privacy Policy](./PRIVACY.md)
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
   
   <p>웹 페이지의 DOM 요소를 직접 클릭해서 선택하고, AI 프롬프트로 바로 내보내는 Chrome 익스텐션</p>
   <p>가상 DOM에 의존하지 않고 실제 DOM을 직접 읽기 때문에, <b>모든 웹 환경에서 동작합니다.</b></p>
-  <p>🌐 <a href="https://dom-ai-bridge.pages.dev/">공식 사이트</a> (개발중)</p>
+  <p>🌐 <a href="https://dom-ai-bridge.pages.dev/">공식 사이트</a></p>
 
   <br>
 
   <a href="https://github.com/Sejin-999/DOM-AI-Bridge">
-    <img src="https://img.shields.io/badge/version-1.0.1-blue" alt="version" />
+    <img src="https://img.shields.io/badge/version-1.0.3-blue" alt="version" />
   </a>
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="manifest v3" />
   <img src="https://img.shields.io/badge/license-MIT-gray" alt="license" />
@@ -161,9 +161,9 @@ UI 주석 — https://example.com
 
 ## 설치 방법
 
-### Chrome Web Store (V.1.0.1)
+### Chrome Web Store (V.1.0.3)
 >
-> <a href = "https://chromewebstore.google.com/detail/dom-ai-bridge/gipfclelhppmafdlajajjkfepiiccnfd"> V 1.0.1 </a>
+> <a href = "https://chromewebstore.google.com/detail/dom-ai-bridge/gipfclelhppmafdlajajjkfepiiccnfd"> V 1.0.3 </a>
 
 ### 개발자 모드로 직접 설치
 
@@ -271,11 +271,37 @@ MCP 서버 연동을 통해 **DOM 선택 → AI → 코드 반영**까지 더 �
 
 ---
 
-## Privacy
+## 권한과 개인정보
 
-- 모든 데이터는 **로컬에서만 처리**
-- 외부 서버에 사용자 데이터 저장 없음
-- 폐쇄망 환경에서도 사용 가능
+DOM AI Bridge는 페이지의 실제 DOM을 직접 선택하는 도구이기 때문에, 사용자가 보고 있는 임의의 웹페이지에서 동작할 수 있어야 합니다.
+그래서 `host_permissions: <all_urls>`를 사용하지만, 이것이 백그라운드에서 자동 수집한다는 뜻은 아닙니다.
+
+### 왜 `<all_urls>`가 필요한가요?
+
+- 사용자가 어떤 사이트에서든 DOM 요소를 클릭해 선택할 수 있어야 합니다.
+- 특정 도메인만 허용하면, 스토어 심사 후 실제 사용 환경에서 많은 사이트가 바로 비대상이 됩니다.
+- 이 권한은 "어디서든 선택 UI를 띄울 수 있는 범위"를 위한 것이지, 별도 서버로 데이터를 모으기 위한 권한이 아닙니다.
+
+### 왜 `all_frames`, `match_about_blank`가 필요한가요?
+
+- 현대 웹페이지는 본문, 임베드, 에디터, 결제창, 광고/도구 패널 등을 `iframe`으로 자주 분리합니다.
+- `all_frames: true`가 없으면 iframe 내부 요소를 선택하거나 강조할 수 없습니다.
+- `match_about_blank: true`가 없으면 `about:blank` 또는 `srcdoc` 기반 iframe 안의 요소를 놓치게 됩니다.
+- 즉, 이 옵션들은 "페이지 전체 DOM 문맥을 일관되게 선택"하기 위해 필요합니다.
+
+### 언제 동작하나요?
+
+- 사용자가 팝업에서 **Start Selecting**을 누르거나 단축키로 선택 모드를 켠 뒤에만 선택 UI가 실질적으로 동작합니다.
+- 자동 클릭, 자동 전송, 자동 수집 도구가 아닙니다.
+- 사용자가 명시적으로 **Copy**를 눌렀을 때만 내보내기가 발생합니다.
+- Webhook 전송도 사용자가 직접 활성화하고 설정한 경우에만 동작합니다.
+
+### 데이터는 어떻게 처리되나요?
+
+- 선택 정보, URL, 하이라이트 설정 등은 기본적으로 **로컬에서만 처리 및 저장**됩니다.
+- 개발자가 운영하는 기본 백엔드에 사용자 데이터를 저장하지 않습니다.
+- 외부 전송은 사용자가 Webhook를 켜고, 복사 액션을 수행한 경우에만 발생합니다.
+- 폐쇄망 환경에서도 기본 기능은 그대로 사용할 수 있습니다.
 
 자세한 내용: [개인정보처리방침](./PRIVACY.md)
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "ext_name": { "message": "DOM AI Bridge" },
-  "ext_description": { "message": "Select DOM elements, generate selectors, and export JSON/Markdown fully offline." },
+  "ext_description": { "message": "Select real DOM elements on any webpage and export them to AI, developer, or share workflows." },
 
   "popup_header_title": { "message": "DOM AI Bridge" },
   "popup_toggle_start": { "message": "Start Selecting" },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
   "ext_name": { "message": "DOM AI Bridge" },
-  "ext_description": { "message": "DOM要素を選択し、セレクターを生成してJSON/Markdownをオフラインでエクスポートできます。" },
+  "ext_description": { "message": "あらゆるWebページで実DOM要素を選択し、AI向け・開発者向け・共有向けにエクスポートできる拡張機能です。" },
 
   "popup_header_title": { "message": "DOM AI Bridge" },
   "popup_toggle_start": { "message": "選択開始" },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,6 +1,6 @@
 {
   "ext_name": { "message": "DOM AI Bridge" },
-  "ext_description": { "message": "DOM 요소 선택, 셀렉터 생성, JSON/Markdown Export — 오프라인 완전 동작" },
+  "ext_description": { "message": "어떤 웹페이지에서든 실제 DOM 요소를 선택하고 AI용, 개발자용, 공유용으로 내보내는 확장 프로그램" },
 
   "popup_header_title": { "message": "DOM AI Bridge" },
   "popup_toggle_start": { "message": "선택 시작" },

--- a/content/dom-utils.js
+++ b/content/dom-utils.js
@@ -120,8 +120,8 @@
    */
   window.__AGT.exportJSON = function (selections) {
     const data = {
-      tool: 'Agentation DOM Inspector',
-      version: '1.0.0',
+      tool: 'DOM AI Bridge',
+      version: '1.0.3',
       url: location.href,
       exportedAt: new Date().toISOString(),
       count: selections.length,

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agentation DOM Inspector</title>
+  <title>DOM AI Bridge</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -896,8 +896,8 @@
   <!-- 헤더 -->
   <div class="header">
     <div class="header-left">
-      <div class="logo">A</div>
-      <span class="title" data-i18n="popup_header_title">Agentation DOM Inspector</span>
+      <div class="logo">D</div>
+      <span class="title" data-i18n="popup_header_title">DOM AI Bridge</span>
     </div>
     <button class="toggle-btn inactive" id="toggleBtn">
       <span class="toggle-dot"></span>
@@ -1084,7 +1084,7 @@
         <a
           class="issue-link-btn issue-link-btn--sm"
           id="issueLinkBtn"
-          href="https://github.com/Sejin-999/agentation-chrome-extentions/issues/4"
+          href="https://github.com/Sejin-999/DOM-AI-Bridge/issues/4"
           target="_blank"
           rel="noopener noreferrer"
           title="Open issue #4"


### PR DESCRIPTION
## 요약
DOM AI Bridge 1.0.3 업데이트에 맞춰 사용자에게 보이는 설명과 메타데이터를 정리했습니다.
Chrome Web Store와 README, 개인정보처리방침에서 제품명과 버전 표기를 일치시켰습니다.
권한 사용 범위와 iframe 대응 이유, 동작 시점이 모두 명시적 사용자 액션 기반이라는 점을 더 분명하게 설명했습니다.
팝업 UI와 export 결과에 남는 이름/버전 정보도 현재 배포 대상 기준으로 맞췄습니다.

## 변경 요약
README 한글/영문 문서에서 공식 사이트, 스토어 버전, 권한 및 개인정보 설명을 1.0.3 기준으로 업데이트했습니다.
PRIVACY.md에서 확장 프로그램명을 DOM AI Bridge로 통일하고 Webhook 전송 조건, 권한 범위, 사용자 액션 기반 동작 방식을 명확히 적었습니다.
_locales/en/messages.json, _locales/ja/messages.json, _locales/ko/messages.json의 확장 설명 문구를 스토어 제출 맥락에 맞게 조정했습니다.
popup/popup.html에서 팝업 타이틀, 헤더 로고 문자, 저장소 이슈 링크를 현재 프로젝트명과 저장소 기준으로 정리했습니다.
content/dom-utils.js에서 export JSON 메타데이터의 tool/version 값을 DOM AI Bridge / 1.0.3으로 갱신했습니다.

## 코드 리뷰(간단)
기능 로직 변경은 거의 없고 문서/문구/메타데이터 정렬이 중심이라 런타임 리스크는 낮습니다.
다만 스토어 설명 문구와 실제 권한/동작이 계속 일치하는지는 다음 배포 때 manifest와 함께 다시 확인하는 편이 안전합니다.
주요 리스크 없음. 테스트는 실행하지 않았습니다.
